### PR TITLE
Match on functions that have apostraphes

### DIFF
--- a/ghcitui.cabal
+++ b/ghcitui.cabal
@@ -150,8 +150,10 @@ test-suite spec
     main-is:            Spec.hs
     type:               exitcode-stdio-1.0
     build-depends:      base >= 4.16 && < 5
+                        , text
                         , ghcitui
                         , hspec ^>= 2.11.5
     other-modules:      LocSpec
+                        , ParseContextSpec
                         , UtilSpec
     default-language:   Haskell2010

--- a/test/ParseContextSpec.hs
+++ b/test/ParseContextSpec.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module ParseContextSpec where
+
+import Data.Text as T
+import Test.Hspec
+
+import qualified Ghcitui.Ghcid.ParseContext as PC
+import qualified Ghcitui.Loc as Loc
+
+spec :: Spec
+spec = do
+    describe "parseContext" $ do
+        it "can parse the Ormolu function parseModule' (with an apostraphe)" $ do
+            let apostrapheFixture =
+                    T.unlines
+                        [ "()"
+                        , "[src/Ormolu.hs:(257,51)-(261,35)] #~GHCID-START~#()"
+                        , "[src/Ormolu.hs:(257,51)-(261,35)] #~GHCID-START~#--> invoke"
+                        , "  Stopped in Ormolu.parseModule', src/Ormolu.hs:(257,51)-(261,35)"
+                        ]
+            let expectedLoc =
+                    Loc.SourceRange
+                        { Loc.startLine = Just 257
+                        , Loc.startCol = Just 51
+                        , Loc.endLine = Just 261
+                        , Loc.endCol = Just 35
+                        }
+            let expected =
+                    PC.PCContext
+                        (PC.ParseContextOut "Ormolu.parseModule'" "src/Ormolu.hs" expectedLoc)
+            PC.parseContext apostrapheFixture `shouldBe` expected

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -3,9 +3,11 @@ module Main where
 import Test.Hspec
 
 import qualified LocSpec
+import qualified ParseContextSpec
 import qualified UtilSpec
 
 main :: IO ()
 main = hspec $ do
     LocSpec.spec
     UtilSpec.spec
+    ParseContextSpec.spec


### PR DESCRIPTION
Apostraphes are of course valid haskell characters in function names. The current ParseContext did not understand this.

Fixes #38 hopefully