### PR TITLE
Match on functions that have apostraphes

### DIFF
--- a/ghcitui.cabal
+++ b/ghcitui.cabal
@@ -150,8 +150,10 @@ test-suite spec
     main-is:            Spec.hs
     type:               exitcode-stdio-1.0
     build-depends:      base >= 4.16 && < 5
+                        , text
                         , ghcitui
                         , hspec ^>= 2.11.5
     other-modules:      LocSpec
+                        , ParseContextSpec
                         , UtilSpec
     default-language:   Haskell2010

--- a/lib/ghcitui-core/Ghcitui/Ghcid/ParseContext.hs
+++ b/lib/ghcitui-core/Ghcitui/Ghcid/ParseContext.hs
@@ -68,9 +68,9 @@ parseFile s
 -- | Parse a source range structure into a SourceRange object.
 parseSourceRange :: T.Text -> Loc.SourceRange
 parseSourceRange s
-    -- Matches (12,34)-(56,78)
+    -- Matches (12,34)-(56,78) ... (line 12, column 34 to line 56, column 78)
     | Just mr <- matches "\\(([0-9]+),([0-9]+)\\)-\\(([0-9]+),([0-9]+)\\)" = fullRange mr
-    -- Matches 12:34-56
+    -- Matches 12:34-56 ... (line 12, columns 34 to 56)
     | Just mr <- matches "([0-9]+):([0-9]+)-([0-9]+)" = lineColRange mr
     -- Matches 12:34
     | Just mr <- matches "([0-9]+):([0-9]+)" = lineColSingle mr
@@ -136,7 +136,7 @@ eInfoLine contextText =
     mStopLineMatchRes = foldr (\n acc -> acc <|> stopReg n) Nothing splits
     -- Match on the "Stopped in ..." line.
     stopReg :: T.Text -> Maybe (MatchResult T.Text)
-    stopReg s = s =~~ ("^[ \t]*Stopped in ([[:alnum:]_.()]+'*),(.*)" :: T.Text)
+    stopReg s = s =~~ ("^[ \t]*Stopped in ([[:alnum:]_.()']+),(.*)" :: T.Text)
 
 parseBreakResponse :: T.Text -> Either T.Text [Loc.ModuleLoc]
 parseBreakResponse t
@@ -212,7 +212,7 @@ parseShowModules t
   where
     stripped = T.strip t
     matchingLines = mapMaybe matching . T.lines <$> lastMay (splitBy ghcidPrompt stripped)
-    reg = "([[:alnum:]_.]+)[ \\t]+\\( *([^,]*),.*\\)" :: T.Text
+    reg = "([[:alnum:]_.']+)[ \\t]+\\( *([^,]*),.*\\)" :: T.Text
     matching :: T.Text -> Maybe (MatchResult T.Text)
     matching = (=~~ reg)
 

--- a/test/ParseContextSpec.hs
+++ b/test/ParseContextSpec.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module ParseContextSpec where
+
+import Data.Text as T
+import Test.Hspec
+
+import qualified Ghcitui.Ghcid.ParseContext as PC
+import qualified Ghcitui.Loc as Loc
+
+spec :: Spec
+spec = do
+    describe "parseContext" $ do
+        it "can parse the Ormolu function parseModule' (with an apostraphe)" $ do
+            let apostrapheFixture =
+                    T.unlines
+                        [ "()"
+                        , "[src/Ormolu.hs:(257,51)-(261,35)] #~GHCID-START~#()"
+                        , "[src/Ormolu.hs:(257,51)-(261,35)] #~GHCID-START~#--> invoke"
+                        , "  Stopped in Ormolu.parseModule', src/Ormolu.hs:(257,51)-(261,35)"
+                        ]
+            let expectedLoc =
+                    Loc.SourceRange
+                        { Loc.startLine = Just 257
+                        , Loc.startCol = Just 51
+                        , Loc.endLine = Just 261
+                        , Loc.endCol = Just 35
+                        }
+            let expected =
+                    PC.PCContext
+                        (PC.ParseContextOut "Ormolu.parseModule'" "src/Ormolu.hs" expectedLoc)
+            PC.parseContext apostrapheFixture `shouldBe` expected

--- a/test/ParseContextSpec.hs
+++ b/test/ParseContextSpec.hs
@@ -11,14 +11,18 @@ import qualified Ghcitui.Loc as Loc
 spec :: Spec
 spec = do
     describe "parseContext" $ do
+        it "can parse fibonacci context" $ do
+            let expectedLoc =
+                    Loc.SourceRange
+                        { Loc.startLine = Just 9
+                        , Loc.startCol = Just 17
+                        , Loc.endLine = Just 9
+                        , Loc.endCol = Just 29
+                        }
+            let expected =
+                    PC.PCContext (PC.ParseContextOut "Yib.fibty.right" "test/Fib.hs" expectedLoc)
+            PC.parseContext fibFixture `shouldBe` expected
         it "can parse the Ormolu function parseModule' (with an apostraphe)" $ do
-            let apostrapheFixture =
-                    T.unlines
-                        [ "()"
-                        , "[src/Ormolu.hs:(257,51)-(261,35)] #~GHCID-START~#()"
-                        , "[src/Ormolu.hs:(257,51)-(261,35)] #~GHCID-START~#--> invoke"
-                        , "  Stopped in Ormolu.parseModule', src/Ormolu.hs:(257,51)-(261,35)"
-                        ]
             let expectedLoc =
                     Loc.SourceRange
                         { Loc.startLine = Just 257
@@ -30,3 +34,20 @@ spec = do
                     PC.PCContext
                         (PC.ParseContextOut "Ormolu.parseModule'" "src/Ormolu.hs" expectedLoc)
             PC.parseContext apostrapheFixture `shouldBe` expected
+
+
+fibFixture :: T.Text
+fibFixture =
+    T.unlines
+        [ "[test/Fib.hs:9:17-29] #~GHCID-START~#[test/Fib.hs:9:17-29] #~GHCID-START~#--> fibty 10"
+        , "  Stopped in Yib.fibty.right, test/Fib.hs:9:17-29"
+        ]
+
+apostrapheFixture :: T.Text
+apostrapheFixture =
+    T.unlines
+        [ "()"
+        , "[src/Ormolu.hs:(257,51)-(261,35)] #~GHCID-START~#()"
+        , "[src/Ormolu.hs:(257,51)-(261,35)] #~GHCID-START~#--> invoke"
+        , "  Stopped in Ormolu.parseModule', src/Ormolu.hs:(257,51)-(261,35)"
+        ]

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -3,9 +3,11 @@ module Main where
 import Test.Hspec
 
 import qualified LocSpec
+import qualified ParseContextSpec
 import qualified UtilSpec
 
 main :: IO ()
 main = hspec $ do
     LocSpec.spec
     UtilSpec.spec
+    ParseContextSpec.spec


### PR DESCRIPTION
Apostraphes are of course valid haskell characters in function names. The current ParseContext did not understand this.

Fixes #38 hopefully