### PR TITLE
Fix 41: Redesign SourceWindow to keep track of extent space

### DIFF
--- a/lib/ghcitui-brick/Ghcitui/Brick/AppConfig.hs
+++ b/lib/ghcitui-brick/Ghcitui/Brick/AppConfig.hs
@@ -43,7 +43,8 @@ data AppConfig = AppConfig
     -- ^ Command to run to initialise the interpreter.
     , getStartupCommands :: ![T.Text]
     -- ^ Commands to run in ghci during start up.
-    } deriving (Show)
+    }
+    deriving (Show)
 
 defaultConfig :: AppConfig
 defaultConfig =

--- a/lib/ghcitui-brick/Ghcitui/Brick/AppConfig.hs
+++ b/lib/ghcitui-brick/Ghcitui/Brick/AppConfig.hs
@@ -43,7 +43,7 @@ data AppConfig = AppConfig
     -- ^ Command to run to initialise the interpreter.
     , getStartupCommands :: ![T.Text]
     -- ^ Commands to run in ghci during start up.
-    }
+    } deriving (Show)
 
 defaultConfig :: AppConfig
 defaultConfig =

--- a/lib/ghcitui-brick/Ghcitui/Brick/AppInterpState.hs
+++ b/lib/ghcitui-brick/Ghcitui/Brick/AppInterpState.hs
@@ -32,7 +32,7 @@ data AppInterpState s n = AppInterpState
     , _cmdHistory :: ![[s]]
     , historyPos :: !Int
     -- ^ Current position
-    }
+    } deriving (Show)
 
 -- | Lens accessor for the editor. See '_liveEditor'.
 liveEditor :: Lens.Lens' (AppInterpState s n) (BE.Editor s n)

--- a/lib/ghcitui-brick/Ghcitui/Brick/AppInterpState.hs
+++ b/lib/ghcitui-brick/Ghcitui/Brick/AppInterpState.hs
@@ -32,7 +32,8 @@ data AppInterpState s n = AppInterpState
     , _cmdHistory :: ![[s]]
     , historyPos :: !Int
     -- ^ Current position
-    } deriving (Show)
+    }
+    deriving (Show)
 
 -- | Lens accessor for the editor. See '_liveEditor'.
 liveEditor :: Lens.Lens' (AppInterpState s n) (BE.Editor s n)

--- a/lib/ghcitui-brick/Ghcitui/Brick/AppState.hs
+++ b/lib/ghcitui-brick/Ghcitui/Brick/AppState.hs
@@ -67,6 +67,7 @@ data WidgetSizes = WidgetSizes
     { _wsInfoWidth :: !Int
     , _wsReplHeight :: !Int
     }
+    deriving (Show)
 
 {- | Application state wrapper.
 
@@ -106,6 +107,7 @@ data AppState n = AppState
     , splashContents :: !(Maybe T.Text)
     -- ^ Splash to show on start up.
     }
+    deriving (Show)
 
 newtype AppStateM m a = AppStateM {runAppStateM :: m a}
 

--- a/lib/ghcitui-brick/Ghcitui/Brick/AppTopLevel.hs
+++ b/lib/ghcitui-brick/Ghcitui/Brick/AppTopLevel.hs
@@ -12,5 +12,6 @@ data AppName
     | BindingViewport
     | ModulesViewport
     | TraceViewport
-    | SourceList
+    | -- | Source Window Name.
+      SourceList
     deriving (Eq, Show, Ord)

--- a/lib/ghcitui-brick/Ghcitui/Brick/Events.hs
+++ b/lib/ghcitui-brick/Ghcitui/Brick/Events.hs
@@ -31,9 +31,11 @@ handleEvent :: B.BrickEvent AppName e -> B.EventM AppName (AppState AppName) ()
 handleEvent (B.VtyEvent (V.EvResize _ _)) = B.invalidateCache
 handleEvent ev = do
     appState <- B.get
-    updatedSourceWindow <- SourceWindow.updateSrcWindowEnd (appState ^. AppState.sourceWindow)
+    updatedSourceWindow <- SourceWindow.updateVerticalSpace (appState ^. AppState.sourceWindow)
     let appStateUpdated = Lens.set AppState.sourceWindow updatedSourceWindow appState
-    let handler = case appStateUpdated.activeWindow of
+    B.put appStateUpdated
+    let handler :: B.BrickEvent AppName e -> B.EventM AppName (AppState AppName) ()
+        handler = case appStateUpdated.activeWindow of
             AppState.ActiveCodeViewport -> handleSrcWindowEvent
             AppState.ActiveLiveInterpreter -> handleInterpreterEvent
             AppState.ActiveInfoWindow -> handleInfoEvent

--- a/lib/ghcitui-brick/Ghcitui/Brick/Events.hs
+++ b/lib/ghcitui-brick/Ghcitui/Brick/Events.hs
@@ -245,7 +245,9 @@ appendToLogs logs promptEntry state = state{interpLogs = take interpreterLogLimi
     -- TODO: Should be configurable?
     interpreterLogLimit = 1000
 
--- | Reflow entries of text into columns.
+{- | Reflow entries of text into columns.
+     Mostly useful right now for printing autocomplete suggestions into columns.
+-}
 reflowText
     :: Int
     -- ^ Num columns
@@ -265,6 +267,7 @@ reflowText numCols colWidth = go
     maxTextLen = colWidth - 1
     makeLine xs = T.concat (T.justifyLeft colWidth ' ' . shortenText maxTextLen <$> xs)
 
+-- | Limit text to a given length, and cut with an elipses.
 shortenText :: Int -> T.Text -> T.Text
 shortenText maxLen text
     | len <= maxLen = text


### PR DESCRIPTION
Originally, SourceWindow was built around a start and an end point.
It turns out, this was a bad idea as it caused update issues when
switching files.

Now we keep around the extent information.

---

Also add some other debug help stuff.

---

Fixes #41 