### PR TITLE
Add newline/delayed prompt for the REPL

### DIFF
--- a/lib/ghcitui-brick/Ghcitui/Brick/AppConfig.hs
+++ b/lib/ghcitui-brick/Ghcitui/Brick/AppConfig.hs
@@ -46,6 +46,7 @@ data AppConfig = AppConfig
     }
     deriving (Show)
 
+-- | Set up the default config for the App startup.
 defaultConfig :: AppConfig
 defaultConfig =
     AppConfig

--- a/lib/ghcitui-brick/Ghcitui/Brick/BrickUI.hs
+++ b/lib/ghcitui-brick/Ghcitui/Brick/BrickUI.hs
@@ -169,10 +169,13 @@ drawBaseLayer s =
                         . reverse
                         $ s.interpLogs
         promptLine :: B.Widget AppName
-        promptLine =
-            B.txt (AppConfig.getInterpreterPrompt . AppState.appConfig $ s)
-                <+> BE.renderEditor displayF enableCursor (s ^. liveEditor)
+        promptLine = promptWidget <+> BE.renderEditor displayF enableCursor (s ^. liveEditor)
           where
+            promptWidget :: B.Widget AppName
+            promptWidget =
+                if AppState.waitingOnRepl s
+                    then B.emptyWidget
+                    else B.txt . AppConfig.getInterpreterPrompt . AppState.appConfig $ s
             displayF :: [T.Text] -> B.Widget AppName
             displayF t = B.vBox $ B.txt <$> t
         lockToBottomOnViewLock w =

--- a/lib/ghcitui-core/Ghcitui/Ghcid/Daemon.hs
+++ b/lib/ghcitui-core/Ghcitui/Ghcid/Daemon.hs
@@ -63,12 +63,13 @@ module Ghcitui.Ghcid.Daemon
 
       -- * Misc
     , isExecuting
+    , readyToExec
     , BreakpointArg (..)
     , interruptDaemon
     , LogOutput (..)
     ) where
 
-import Control.Concurrent (MVar, forkIO, newEmptyMVar, newMVar, putMVar, takeMVar)
+import Control.Concurrent (MVar, forkIO, newEmptyMVar, newMVar, putMVar, takeMVar, isEmptyMVar)
 import Control.Error
 import Control.Monad (when)
 import Control.Monad.IO.Class (MonadIO (..))
@@ -174,10 +175,16 @@ appendExecHist cmd s@InterpState{execHist} = s{execHist = cmd : execHist}
      Note, this does not indicate whether there's a scheduled 'DaemonIO' operation,
      but rather just indicates whether we have stopped at a breakpoint in the middle
      of evaluation.
+
+     Use 'readyToExec' if you want to query the state of the actual underlying handle.
 -}
 isExecuting :: InterpState a -> Bool
 isExecuting InterpState{func = Nothing} = False
 isExecuting InterpState{func = Just _} = True
+
+-- | Is the GHCi lock busy?
+readyToExec :: InterpState a -> IO Bool
+readyToExec s = isEmptyMVar (_ghciLock s)
 
 -- | Start up the GHCi Daemon.
 startup

--- a/lib/ghcitui-core/Ghcitui/Util.hs
+++ b/lib/ghcitui-core/Ghcitui/Util.hs
@@ -6,9 +6,10 @@ module Ghcitui.Util
     , getNumDigits
     , formatDigits
     , dropMiddleToFitText
+    , revealNewlines
     ) where
 
-import Data.Text (Text, breakOn, drop, length, pack, take, takeEnd)
+import Data.Text (Text, breakOn, drop, length, pack, replace, take, takeEnd)
 import Prelude hiding (drop, length, take)
 
 -- | Split text based on a delimiter.
@@ -77,3 +78,6 @@ dropMiddleToFitText w text
     halfWidth = fromIntegral (w - 1) / 2.0 :: Float
     prefix = take (floor halfWidth) text
     suffix = takeEnd (ceiling halfWidth) text
+
+revealNewlines :: Text -> Text
+revealNewlines = replace "\n" "↓"


### PR DESCRIPTION
In Issue #49, it was pointed out that it's confusing to see the prompt not change after hitting enter when
an infinite loop was made. This PR fixes the issue by entering a newline, and hiding the prompt while
a long-running executing command is running in the Live Interpreter window.