### PR TITLE
Force upgrade fsnotify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Revision history for ghcitui
 
+## 0.4.1.0 -- 2024-11-16
+
+### Bug fixes
+
+- Fixed dependency error with `fsnotify` failing to build due to
+  `text` show conflict.
+
 ## 0.4.0.0 -- 2024-11-15
 
 ### New features

--- a/MANUAL.rst
+++ b/MANUAL.rst
@@ -9,20 +9,20 @@ CLI Synopsis
 .. code-block::
 
   Usage: ghcitui [--version] [--debug-console] [-v] [--daemon-log LOGFILE]
-                [-c|--cmd CMD] [-C|--workdir DIR] [TARGET]
+                 [-c|--cmd CMD] [-C|--workdir DIR] [TARGET]
 
-    ghcitui: A TUI interface for GHCi
+    ghcitui: A TUI interface for GHCi. Press '?' while running for full help.
 
   Available options:
     -h,--help                Show this help text
     --version                Print the version number and exit
     --debug-console          Display the debug console
     -v                       Set verbosity for output logs. Pass multiple times
-                            (e.g -vvv) to increase the logging. Use --daemon-log
-                            to specify where the logs go.
+                             (e.g -vvv) to increase the logging. Use --daemon-log
+                             to specify where the logs go.
     --daemon-log LOGFILE     File path for debugging daemon logs. Used with -v.
-                            Setting this to 'stdout' or 'stderr' sends logs to
-                            each, respectively. Defaults to /tmp/ghcitui.log.
+                             Setting this to 'stdout' or 'stderr' sends logs to
+                             each, respectively. Defaults to 'stderr'
     -c,--cmd CMD             Command to start the internal interpreter
     -C,--workdir DIR         Set working dir
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -98,6 +98,6 @@ main = do
     programName = "ghcitui"
     programDescription = Opt.progDesc (
             programName <> ": A TUI interface for GHCi."
-            <> "Press '?' while running for full help."
+            <> " Press '?' while running for full help."
         )
     parserInfo = Opt.info (Opt.helper <*> parseOpts) (Opt.fullDesc <> programDescription)

--- a/gen/MANUAL.txt
+++ b/gen/MANUAL.txt
@@ -1,19 +1,19 @@
 CLI SYNOPSIS
           Usage: ghcitui [--version] [--debug-console] [-v] [--daemon-log LOGFILE]
-                        [-c|--cmd CMD] [-C|--workdir DIR] [TARGET]
+                         [-c|--cmd CMD] [-C|--workdir DIR] [TARGET]
 
-            ghcitui: A TUI interface for GHCi
+            ghcitui: A TUI interface for GHCi. Press '?' while running for full help.
 
           Available options:
             -h,--help                Show this help text
             --version                Print the version number and exit
             --debug-console          Display the debug console
             -v                       Set verbosity for output logs. Pass multiple times
-                                    (e.g -vvv) to increase the logging. Use --daemon-log
-                                    to specify where the logs go.
+                                     (e.g -vvv) to increase the logging. Use --daemon-log
+                                     to specify where the logs go.
             --daemon-log LOGFILE     File path for debugging daemon logs. Used with -v.
-                                    Setting this to 'stdout' or 'stderr' sends logs to
-                                    each, respectively. Defaults to /tmp/ghcitui.log.
+                                     Setting this to 'stdout' or 'stderr' sends logs to
+                                     each, respectively. Defaults to 'stderr'
             -c,--cmd CMD             Command to start the internal interpreter
             -C,--workdir DIR         Set working dir
 

--- a/ghcitui.cabal
+++ b/ghcitui.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               ghcitui
-version:            0.4.0.0
+version:            0.4.1.0
 synopsis:           A Terminal User Interface (TUI) for GHCi
 
 description:
@@ -79,7 +79,10 @@ library
                         , regex-base ^>= 0.94.0.2
                         , regex-tdfa >= 1.3.2 && < 1.4
                         , string-interpolate >= 0.3.2.1 && < 0.4
-                        , text >= 2.0 && < 2.2
+                        -- Pinned to less than 2.1.2, because it breaks
+                        -- with FSNotify.
+                        , text >= 2.0 && < 2.3
+                        , fsnotify ^>= 0.4.1.0
                         , transformers ^>= 0.6.1.0
                         -- Needed to limit string-interpolate compat.
                         , utf8-string >= 1.0.2 && < 1.1


### PR DESCRIPTION
This breaks for whatever reason only on hackage. It appears ghcid depends on fsnotify as an executable, but not as a library. We're not using it as an executable, but perhaps the documentation is breaking on it. I'm uncertain why we're building the executable dependencies, but until that's fixed we can't do anything except either downgrade text or force upgrade fsnotify.